### PR TITLE
Allow color averaging over multiple Ambilight positions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+/target/

--- a/src/main/java/com/matthiaswelz/ambihue/Ambihue.java
+++ b/src/main/java/com/matthiaswelz/ambihue/Ambihue.java
@@ -37,8 +37,8 @@ public class Ambihue {
 		this.reader = ambilightReader;
 		
 		this.semaphore = new Semaphore(0);
-		this.data = new AtomicReference<AmbilightData>(null);
-		this.associations = new ArrayList<HueAmbilightMapping>();
+		this.data = new AtomicReference<>(null);
+		this.associations = new ArrayList<>();
 		this.running = new AtomicBoolean(false);
 		
 		this.ambilightReadTimer = new Timer(true);

--- a/src/main/java/com/matthiaswelz/ambihue/AveragedAmbilightMapping.java
+++ b/src/main/java/com/matthiaswelz/ambihue/AveragedAmbilightMapping.java
@@ -1,0 +1,112 @@
+package com.matthiaswelz.ambihue;
+
+import java.util.ArrayList;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.logging.log4j.util.Strings;
+
+import com.matthiaswelz.ambihue.AmbilightData.Position;
+
+public class AveragedAmbilightMapping extends HueAmbilightMapping {
+	static class LightPart {
+		private Position position;
+		private int index;
+		private double weight;
+		
+		public LightPart(Position position, int index, double weight) {
+			assert weight > 0;
+			
+			this.position = position;
+			this.index = index;
+			this.weight = weight;
+		}
+	}
+	
+	static Pattern mainPattern = Pattern.compile("^(?<lightName>[^:]+):(?<lights>([^:,]+,?){2,})(:(?<brightness>[0-9]{0,3}))?$");
+	static Pattern partPattern = Pattern.compile("^(?<weight>[0-9]*(\\.[0-9]+)?)?(?<position>[A-Za-z]+)(?<index>[0-9]),?$"); 
+	
+	public static boolean isFit(String mapping) {
+		return mainPattern.matcher(mapping).matches();
+	}
+	public static AveragedAmbilightMapping parse(String mapping) {
+		logger.trace("Matching: " + mapping);
+		
+		Matcher mainMatcher = mainPattern.matcher(mapping);
+		if (!mainMatcher.matches()) {
+			logger.trace("No match");
+			return null;
+		}
+
+		logger.trace("Matched");
+		
+		String lightName = mainMatcher.group("lightName");
+		logger.trace("lightName: " + lightName);
+		
+		String brightness = mainMatcher.group("brightness");
+		logger.trace("brightness: " + brightness);
+		if (brightness == null) {
+			brightness = "100";
+			logger.trace("Defaulting to brightness: " + brightness);
+		}
+		
+		ArrayList<LightPart> lightParts = new ArrayList<>();
+		String lights = mainMatcher.group("lights");
+		logger.trace("lights: " + lights);
+		
+		String[] parts = lights.split(",");
+		logger.trace("number of parts: " + parts.length);
+		
+		for (String part : parts) {
+			logger.trace("  matching part: " + part);
+			Matcher partMatcher = partPattern.matcher(part);
+			if (!partMatcher.matches()) {
+				logger.trace("    No part match");
+				return null;
+			}
+			
+			String position = partMatcher.group("position");
+			logger.trace("    position: " + position);
+			
+			String index = partMatcher.group("index");
+			logger.trace("    index: " + index);
+
+			String weight = partMatcher.group("weight");
+			logger.trace("    weight: " + weight);
+			
+			if (Strings.isEmpty(weight))
+				weight = "1";
+			if (weight.startsWith("."))
+				weight = "0" + weight;
+			
+			LightPart lightPart = new LightPart(Position.valueOf(position), Integer.parseInt(index), Double.parseDouble(weight));
+			lightParts.add(lightPart);
+			
+			logger.trace("    added part");
+		}
+
+		
+		return new AveragedAmbilightMapping(lightName, Integer.parseInt(brightness), lightParts);
+	}
+
+	private final Iterable<LightPart> lightParts;
+	
+	protected AveragedAmbilightMapping(String lightName, int brightness, Iterable<LightPart> lightParts) {
+		super(lightName, brightness);
+		
+		this.lightParts = lightParts;
+	}
+	
+	@Override
+	protected Color calculateColor(AmbilightData data) {
+		ColorAverager averager = new ColorAverager();
+		
+		for (LightPart lightPart : lightParts) {
+			Color lightColor = data.getColor(lightPart.position, lightPart.index);
+			averager.addColor(lightColor, lightPart.weight);
+		}
+		
+		return averager.calculateResult();
+	}
+	
+}

--- a/src/main/java/com/matthiaswelz/ambihue/ColorAverager.java
+++ b/src/main/java/com/matthiaswelz/ambihue/ColorAverager.java
@@ -1,0 +1,50 @@
+package com.matthiaswelz.ambihue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+
+import com.stackoverflow.finnw.CIELab;
+
+public class ColorAverager {
+	private final List<Pair<Color, Double>> colors;
+
+	public ColorAverager() {
+		this.colors = new ArrayList<>();
+	}
+
+	public void addColor(Color color, double weight) {
+		assert color != null;
+		assert weight > 0;
+
+		this.colors.add(new ImmutablePair<Color, Double>(color, weight));
+	}
+
+	public Color calculateResult() {
+		float totalL = 0;
+		float totalA = 0;
+		float totalB = 0;
+		float totalWeight = 0;
+
+		for (Pair<Color, Double> pair : colors) {
+			Color color = pair.getKey();
+			double weight = pair.getValue();
+
+			float[] lab = CIELab.getInstance().fromRGB(new float[] { (color.getR() & 0xFF) / 255.0f, (color.getG() & 0xFF) / 255.0f, (color.getB() & 0xFF) / 255.0f});
+
+			totalL += lab[0] * weight;
+			totalA += lab[1] * weight;
+			totalB += lab[2] * weight;
+			totalWeight += weight;
+		}
+
+		float l = totalL / totalWeight;
+		float a = totalA / totalWeight;
+		float b = totalB / totalWeight;
+
+		float[] rgb = CIELab.getInstance().toRGB(new float[] { l, a, b });
+		return new Color((byte)(int) (rgb[0] * 255 + 0.5f), (byte)(int) (rgb[1] * 255 + 0.5f), (byte)(int) (rgb[2] * 255 + 0.5f));
+	}
+}

--- a/src/main/java/com/matthiaswelz/ambihue/HueAmbilightMapping.java
+++ b/src/main/java/com/matthiaswelz/ambihue/HueAmbilightMapping.java
@@ -1,91 +1,75 @@
 package com.matthiaswelz.ambihue;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import com.matthiaswelz.ambihue.AmbilightData.Position;
 import com.matthiaswelz.ambihue.HueController.LightState;
 
-public class HueAmbilightMapping {
+public abstract class HueAmbilightMapping {
 	static Logger logger = LogManager.getLogger();
-	
-	static Pattern pattern = Pattern.compile("^(?<lightName>[^:]+):(?<position>[A-Za-z]+)(?<index>[0-9])(:(?<brightness>[0-9]{0,3}))?$");
-	
-	public static HueAmbilightMapping parse(String mapping) {
-		logger.trace("Matching: " + mapping);
-		
-		Matcher matcher = pattern.matcher(mapping);
-		if (!matcher.matches()) {
-			logger.trace("No match");
-			return null;
-		}
 
-		logger.trace("Matched");
+	//TODO: Change to factory pattern if needed
+	public static HueAmbilightMapping parse(String mapping) {
+		if (SimpleHueAmbilightMapping.isFit(mapping))
+			return SimpleHueAmbilightMapping.parse(mapping);
 		
-		String lightName = matcher.group("lightName");
-		logger.trace("lightName: " + lightName);
-		
-		String position = matcher.group("position");
-		logger.trace("position: " + position);
-		
-		String index = matcher.group("index");
-		logger.trace("index: " + index);
-		
-		String brightness = matcher.group("brightness");
-		logger.trace("brightness: " + brightness);
-		if (brightness == null) {
-			brightness = "100";
-			logger.trace("Defaulting to brightness: " + brightness);
-		}
-		
-		return new HueAmbilightMapping(lightName, Position.valueOf(position), Integer.parseInt(index), Integer.parseInt(brightness));
+		assert AveragedAmbilightMapping.isFit(mapping);
+		return AveragedAmbilightMapping.parse(mapping);
 	}
-	
+
 	private String lightName;
-	private Position position;
-	private int index;
 	private int brightness;
+	
 	private LightState savedState;
 	
-	public HueAmbilightMapping(String lightName, Position position, int index, int brightness) {
+	protected HueAmbilightMapping(String lightName, int brightness) {
+		assert brightness > 0;
+		assert lightName != null;
+		
 		this.lightName = lightName;
-		this.position = position;
-		this.index = index;
 		this.brightness = brightness;
 	}
-	
-	protected void prepareLight(HueController hueController) {
+
+	public void prepareLight(HueController hueController) {
+		assert hueController != null;
 		assert this.savedState == null;
 		
 		logger.debug("Preparing light " + this.lightName);
 		this.savedState = hueController.saveLightState(this.lightName);
 		hueController.setBrightness(this.lightName, this.brightness);
 	}
-	protected void unprepareLight(HueController hueController) {
-		assert this.savedState != null;
 
+	public void unprepareLight(HueController hueController) {
+		assert hueController != null;
+		assert this.savedState != null;
+	
 		logger.debug("Unpreparing light " + this.lightName);
 		hueController.restoreLightState(this.savedState);
 		this.savedState = null;
 	}
-	protected void apply(HueController hueController, AmbilightData data) {	
-		logger.trace("Applying new color value to " + this.lightName);
+
+	public void apply(HueController hueController, AmbilightData data) {
+		assert hueController != null;
+		assert data != null;
+		assert this.savedState != null;
 		
-		Color color = data.getColor(this.position, this.index);
+		logger.trace("Calculating new color value for " + this.lightName);
+		
+		Color color = this.calculateColor(data);
+		assert color != null;
 		hueController.setColor(lightName, color);
+
+		logger.trace("Applied color: " + color);
 	}
+	
+	protected abstract Color calculateColor(AmbilightData data);
 	
 	@Override
 	public String toString() {
 		return new ToStringBuilder(this)
-				.append("lightName", lightName)
-				.append("position", position)
-				.append("index", index)
-				.append("brightness", brightness)
-				.build();
+			.append("lightName", lightName)
+			.append("brightness", brightness)
+			.toString();
 	}
 }

--- a/src/main/java/com/matthiaswelz/ambihue/Parameters.java
+++ b/src/main/java/com/matthiaswelz/ambihue/Parameters.java
@@ -19,7 +19,7 @@ public class Parameters {
 	public int ambilightTimeoutMS = 100;
 	@Option(name="-tvOffDelay", depends={"-start"},usage="Sets the time (in ms) after which the system should assume that the TV has been turned off")
 	public int tvOffDelay = 3000;
-	@Option(name = "-map", depends={"-start"}, handler=StringArrayOptionHandler.class, usage="Mappings between ambilight positions and light names. Syntax: [Light name]:[Ambilight Position][Ambilight Index]:[Brightness]")
+	@Option(name = "-map", depends={"-start"}, handler=StringArrayOptionHandler.class, usage="Mappings between ambilight positions and light names. Syntax: [Light name]:[Ambilight Position][Ambilight Index]:[Brightness] for simple or [Light name]:[Ambilights]:[Brightness] where Ambilights multiple of (separated by comma): [Weight][Ambilight Position][Ambilight Index]")
 	public List<String> mappings = new ArrayList<String>();
 	@Option(name="-tvCheckInterval", depends={"-start"},usage="Sets the interval (in ms) to check the TV after it has been turned off")
 	public int tvCheckIntervalMs = 5000;

--- a/src/main/java/com/matthiaswelz/ambihue/SimpleHueAmbilightMapping.java
+++ b/src/main/java/com/matthiaswelz/ambihue/SimpleHueAmbilightMapping.java
@@ -1,0 +1,72 @@
+package com.matthiaswelz.ambihue;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.matthiaswelz.ambihue.AmbilightData.Position;
+
+public class SimpleHueAmbilightMapping extends HueAmbilightMapping {
+	static Logger logger = LogManager.getLogger();
+	
+	static Pattern pattern = Pattern.compile("^(?<lightName>[^:]+):(?<position>[A-Za-z]+)(?<index>[0-9])(:(?<brightness>[0-9]{0,3}))?$");
+	
+	public static boolean isFit(String mapping) {
+		return pattern.matcher(mapping).matches();
+	}
+	public static SimpleHueAmbilightMapping parse(String mapping) {
+		logger.trace("Matching: " + mapping);
+		
+		Matcher matcher = pattern.matcher(mapping);
+		if (!matcher.matches()) {
+			logger.trace("No match");
+			return null;
+		}
+
+		logger.trace("Matched");
+		
+		String lightName = matcher.group("lightName");
+		logger.trace("lightName: " + lightName);
+		
+		String position = matcher.group("position");
+		logger.trace("position: " + position);
+		
+		String index = matcher.group("index");
+		logger.trace("index: " + index);
+		
+		String brightness = matcher.group("brightness");
+		logger.trace("brightness: " + brightness);
+		if (brightness == null) {
+			brightness = "100";
+			logger.trace("Defaulting to brightness: " + brightness);
+		}
+		
+		return new SimpleHueAmbilightMapping(lightName, Position.valueOf(position), Integer.parseInt(index), Integer.parseInt(brightness));
+	}
+	
+	private Position position;
+	private int index;
+	
+	public SimpleHueAmbilightMapping(String lightName, Position position, int index, int brightness) {
+		super(lightName, brightness);
+		
+		this.position = position;
+		this.index = index;
+	}
+	
+	protected Color calculateColor(AmbilightData data) {	
+		return data.getColor(this.position, this.index);
+	}
+	
+	@Override
+	public String toString() {
+		return new ToStringBuilder(this)
+				.appendSuper(super.toString())
+				.append("position", position)
+				.append("index", index)
+				.build();
+	}
+}

--- a/src/main/java/com/stackoverflow/finnw/CIELab.java
+++ b/src/main/java/com/stackoverflow/finnw/CIELab.java
@@ -1,0 +1,96 @@
+package com.stackoverflow.finnw;
+
+import java.awt.color.ColorSpace;
+
+/**
+ *  Taken from stackoverflow.com: http://stackoverflow.com/a/5021831 / Licensed under CC-BY-SA
+ * @author finnw ( https://stackoverflow.com/users/12048/finnw )
+ */
+
+public class CIELab extends ColorSpace {
+
+    public static CIELab getInstance() {
+        return Holder.INSTANCE;
+    }
+
+    @Override
+    public float[] fromCIEXYZ(float[] colorvalue) {
+        double l = f(colorvalue[1]);
+        double L = 116.0 * l - 16.0;
+        double a = 500.0 * (f(colorvalue[0]) - l);
+        double b = 200.0 * (l - f(colorvalue[2]));
+        return new float[] {(float) L, (float) a, (float) b};
+    }
+
+    @Override
+    public float[] fromRGB(float[] rgbvalue) {
+        float[] xyz = CIEXYZ.fromRGB(rgbvalue);
+        return fromCIEXYZ(xyz);
+    }
+
+    @Override
+    public float getMaxValue(int component) {
+        return 128f;
+    }
+
+    @Override
+    public float getMinValue(int component) {
+        return (component == 0)? 0f: -128f;
+    }    
+
+    @Override
+    public String getName(int idx) {
+        return String.valueOf("Lab".charAt(idx));
+    }
+
+    @Override
+    public float[] toCIEXYZ(float[] colorvalue) {
+        double i = (colorvalue[0] + 16.0) * (1.0 / 116.0);
+        double X = fInv(i + colorvalue[1] * (1.0 / 500.0));
+        double Y = fInv(i);
+        double Z = fInv(i - colorvalue[2] * (1.0 / 200.0));
+        return new float[] {(float) X, (float) Y, (float) Z};
+    }
+
+    @Override
+    public float[] toRGB(float[] colorvalue) {
+        float[] xyz = toCIEXYZ(colorvalue);
+        return CIEXYZ.toRGB(xyz);
+    }
+
+    CIELab() {
+        super(ColorSpace.TYPE_Lab, 3);
+    }
+
+    private static double f(double x) {
+        if (x > 216.0 / 24389.0) {
+            return Math.cbrt(x);
+        } else {
+            return (841.0 / 108.0) * x + N;
+        }
+    }
+
+    private static double fInv(double x) {
+        if (x > 6.0 / 29.0) {
+            return x*x*x;
+        } else {
+            return (108.0 / 841.0) * (x - N);
+        }
+    }
+
+    private Object readResolve() {
+        return getInstance();
+    }
+
+    private static class Holder {
+        static final CIELab INSTANCE = new CIELab();
+    }
+
+    private static final long serialVersionUID = 5027741380892134289L;
+
+    private static final ColorSpace CIEXYZ =
+        ColorSpace.getInstance(ColorSpace.CS_CIEXYZ);
+
+    private static final double N = 4.0 / 29.0;
+
+}


### PR DESCRIPTION
As [suggested by shinmai](http://disq.us/p/19tphh3): 

> A suggestion for the mappings: an average of a number of ambilight positions mapped to one bulb. I only have one bulb in the same room with the TV and picking just one position can make the bulb act very "buzy", but taking an average of say three positions from the top of the tv and one from each side would usually result in a nice complementary color for the bulb

First draft for the implementation
